### PR TITLE
Wait for build to start before streaming the console

### DIFF
--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -20,7 +20,7 @@ function create(name, config, cb) {
   this.opts.body         = config;
 
   this.opts.handlers[200] = util.passThroughSuccess;
-  this.opts.handlers[400] = util.htmlError; 
+  this.opts.handlers[400] = util.htmlError;
 
   req.request('post', this.url + '/createItem/api/json', this.opts, cb);
 }
@@ -101,12 +101,24 @@ function build(name, params, cb) {
 
   this.opts.queryStrings = { token: 'nestor', json: JSON.stringify(body) };
 
-  this.opts.handlers[200] = util.passThroughSuccess; // backward compatibility for old Jenkins versions
-  this.opts.handlers[201] = util.passThroughSuccess;
+  this.opts.handlers[201] = util.passThroughResponse;
+  this.opts.handlers[200] = util.passThroughResponse; // backward compatibility for old Jenkins versions
   this.opts.handlers[404] = util.jobNotFoundError(name);
   this.opts.handlers[405] = util.jobRequireParamsError(name); // backward compatibility for old Jenkins versions
 
   req.request('post', this.url + '/job/' + name + '/build', this.opts, cb);
+}
+
+function checkStarted(buildUrl, cb) {
+  this.opts.handlers[200] = util.passThroughSuccessJson;
+
+  req.request('get', buildUrl + 'api/json', this.opts, function (err, result) {
+    if (result && result.executable && result.executable.url) {
+      cb(true);
+    } else {
+      cb(false);
+    }
+  });
 }
 
 /**
@@ -234,7 +246,7 @@ function copy(existingName, newName, cb) {
   this.opts.headers      = { 'content-type': 'text/plain' };
 
   this.opts.handlers[200] = util.passThroughSuccess;
-  this.opts.handlers[400] = util.htmlError; 
+  this.opts.handlers[400] = util.htmlError;
 
   req.request('post', this.url + '/createItem', this.opts, cb);
 }
@@ -271,6 +283,7 @@ exports.readLatest    = readLatest;
 exports.update        = update;
 exports.delete        = _delete;
 exports.build         = build;
+exports.checkStarted  = checkStarted;
 exports.stop          = stop;
 exports.streamConsole = streamConsole;
 exports.enable        = enable;

--- a/lib/api/util.js
+++ b/lib/api/util.js
@@ -1,6 +1,16 @@
 var text = require('bagoftext');
 
 /**
+ * Handle success simply by passing the entire response through to callback
+ *
+ * @param {Object} result: result of the sent request as a string
+ * @param {Function} cb: standard cb(err, result) callback
+ */
+function passThroughResponse(result, cb) {
+  cb(null, result);
+}
+
+/**
  * Handle success simply by passing result's (response) body through to callback.
  *
  * @param {Object} result: result of the sent request as a string
@@ -71,6 +81,7 @@ function viewNotFoundError(name) {
   };
 }
 
+exports.passThroughResponse    = passThroughResponse;
 exports.passThroughSuccess     = passThroughSuccess;
 exports.passThroughSuccessJson = passThroughSuccessJson;
 exports.htmlError              = htmlError;

--- a/lib/cli/job.js
+++ b/lib/cli/job.js
@@ -141,8 +141,9 @@ function build(cb) {
     }
 
     function resultCb(result) {
-      console.log(text.__('Job %s was started successfully'), name);
+      console.log(text.__('Job %s was triggered successfully'), name);
     }
+
     function jenkinsCb(jenkins) {
 
       // simply pass jenkins instance to the next callback
@@ -160,15 +161,41 @@ function build(cb) {
         });
       }
 
+      var jenkinsPollIntervalMillis = 2000;
+      var jenkinsPollRetries = args.poll || 15;
+
+      function streamIfReady(buildUrl, ready, retries) {
+        if (ready) {
+          _console(passThroughCb)(name, args);
+        } else {
+          if (retries > 0) {
+            console.log('Waiting for job to start...');
+            setTimeout(function () {
+              jenkins.checkBuildStarted(buildUrl, function (ready) {
+                streamIfReady(buildUrl, ready, retries - 1);
+              });
+            }, jenkinsPollIntervalMillis);
+          } else {
+            console.log(text.__('Build didn\'t start after %d seconds, it\'s still waiting in the queue'),
+                        (jenkinsPollIntervalMillis * jenkinsPollRetries) / 1000);
+            cli.exit({}, null);
+          }
+        }
+      }
+
       var cb;
-      // with console enabled, display result and sleep for 5 seconds then stream console output
+      // with console enabled, display result and poll until the job starts, then stream console output
       if (args.console) {
-        cb = function (err, result) {
-          resultCb(result);
+        cb = function (err, response) {
+          resultCb(response);
+          var buildUrl = response.headers.location;
           setTimeout(function () {
-            _console(passThroughCb)(name, args);
-          }, args.pending || 5000);
+            jenkins.checkBuildStarted(buildUrl, function (ready) {
+              streamIfReady(buildUrl, ready, jenkinsPollRetries);
+            });
+          }, jenkinsPollIntervalMillis);
         };
+
       // with console disabled, display result
       } else {
         cb = cli.exitCb(null, resultCb);

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -183,33 +183,34 @@ function monitor(opts, cb) {
   new cron.CronJob(opts.schedule || '0 * * * * *', _notify).start();
 }
 
-Jenkins.prototype.discover         = jenkins.discover;
-Jenkins.prototype.computer         = jenkins.computer;
-Jenkins.prototype.info             = jenkins.info;
-Jenkins.prototype.monitor          = monitor;
-Jenkins.prototype.parseFeed        = jenkins.parseFeed;
-Jenkins.prototype.queue            = jenkins.queue;
-Jenkins.prototype.version          = jenkins.version;
+Jenkins.prototype.discover          = jenkins.discover;
+Jenkins.prototype.computer          = jenkins.computer;
+Jenkins.prototype.info              = jenkins.info;
+Jenkins.prototype.monitor           = monitor;
+Jenkins.prototype.parseFeed         = jenkins.parseFeed;
+Jenkins.prototype.queue             = jenkins.queue;
+Jenkins.prototype.version           = jenkins.version;
 
-Jenkins.prototype.createJob        = job.create;
-Jenkins.prototype.readJob          = job.read;
-Jenkins.prototype.readLatestJob    = job.readLatest;
-Jenkins.prototype.updateJob        = job.update;
-Jenkins.prototype.deleteJob        = job.delete;
-Jenkins.prototype.buildJob         = job.build;
-Jenkins.prototype.stopJob          = job.stop;
-Jenkins.prototype.streamJobConsole = job.streamConsole;
-Jenkins.prototype.enableJob        = job.enable;
-Jenkins.prototype.disableJob       = job.disable;
-Jenkins.prototype.copyJob          = job.copy;
-Jenkins.prototype.fetchJobConfig   = job.fetchConfig;
-Jenkins.prototype.parseJobFeed     = job.parseFeed;
+Jenkins.prototype.createJob         = job.create;
+Jenkins.prototype.readJob           = job.read;
+Jenkins.prototype.readLatestJob     = job.readLatest;
+Jenkins.prototype.updateJob         = job.update;
+Jenkins.prototype.deleteJob         = job.delete;
+Jenkins.prototype.buildJob          = job.build;
+Jenkins.prototype.checkBuildStarted = job.checkStarted;
+Jenkins.prototype.stopJob           = job.stop;
+Jenkins.prototype.streamJobConsole  = job.streamConsole;
+Jenkins.prototype.enableJob         = job.enable;
+Jenkins.prototype.disableJob        = job.disable;
+Jenkins.prototype.copyJob           = job.copy;
+Jenkins.prototype.fetchJobConfig    = job.fetchConfig;
+Jenkins.prototype.parseJobFeed      = job.parseFeed;
 
-Jenkins.prototype.createView       = view.create;
-Jenkins.prototype.readView         = view.read;
-Jenkins.prototype.updateView       = view.update;
-Jenkins.prototype.fetchViewConfig  = view.fetchConfig;
-Jenkins.prototype.parseViewFeed    = view.parseFeed;
+Jenkins.prototype.createView        = view.create;
+Jenkins.prototype.readView          = view.read;
+Jenkins.prototype.updateView        = view.update;
+Jenkins.prototype.fetchViewConfig   = view.fetchConfig;
+Jenkins.prototype.parseViewFeed     = view.parseFeed;
 
 Jenkins.executorSummary = executorSummary;
 

--- a/test/api/job.js
+++ b/test/api/job.js
@@ -111,6 +111,32 @@ buster.testCase('api - job', {
     });
     job.build('somejob', { someparam1: 'somevalue1', someparam2: 'somevalue2' }, done);
   },
+  'checkStarted - returns true when build has an executable url': function (done) {
+    var expectStarted = function(ready) {
+      assert.equals(ready, true);
+      done();
+    };
+    this.stub(req, 'request', function (method, url, opts, cb) {
+      assert.equals(method, 'get');
+      assert.equals(url, 'https://localhost:8080/queue/item/15032/api/json');
+      assert.defined(opts.handlers[200]);
+      cb(null, {executable: {url: 'someurl'}});
+    });
+    job.checkStarted('https://localhost:8080/queue/item/15032/', expectStarted);
+  },
+  'checkStarted - returns false when build does not yet have an executable url': function (done) {
+    var expectNotStarted = function(ready) {
+      assert.equals(ready, false);
+      done();
+    };
+    this.stub(req, 'request', function (method, url, opts, cb) {
+      assert.equals(method, 'get');
+      assert.equals(url, 'https://localhost:8080/queue/item/15032/api/json');
+      assert.defined(opts.handlers[200]);
+      cb(null, {});
+    });
+    job.checkStarted('https://localhost:8080/queue/item/15032/', expectNotStarted);
+  },
   'streamConsole - should send request to API endpoint': function (done) {
     this.stub(req, 'request', function (method, url, opts, cb) {
       assert.equals(method, 'get');

--- a/test/api/util.js
+++ b/test/api/util.js
@@ -10,6 +10,14 @@ buster.testCase('api - util', {
   setUp: function () {
     this.mock({});
   },
+  'passThroughResponse - should pass entire response': function (done) {
+    function cb(err, result) {
+      assert.isNull(err);
+      assert.equals(result, 'someresponse');
+      done();
+    }
+    util.passThroughResponse('someresponse', cb);
+  },
   'passThroughSuccess - should pass result body': function (done) {
     function cb(err, result) {
       assert.isNull(err);


### PR DESCRIPTION
Ensure that when you trigger a job like:

    nestor build --console myjob

the console output is associated with the newly created build (and not the previous build) even if the newly created build takes longer than 5 seconds to start.

This change involves using the 'Location' returned when a job is triggered to monitor the new build and proceed to stream the console _only_ when the API indicates that the build has started. nestor will poll the monitoring URL every 2 seconds, up to a maximum of 30 seconds (when it will give up).

@cliffano let me know if you want me to change anything. I'm not primarily a js developer so I might have missed some better ways to do things 🙂